### PR TITLE
Store slider images next to other spree images

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -7,7 +7,7 @@ h2. Installation
 To install, add spree_slider to your @Gemfile@ and run `bundle install`:
 
 <pre>
-gem 'spree_slider', github: 'priviterag/spree_slider'
+gem 'spree_slider', github: 'spree-contrib/spree_slider'
 </pre>
 
 Then install and run the migrations to add the tables:

--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -1,6 +1,9 @@
 class Spree::Slide < ActiveRecord::Base
 
-  has_attached_file :image
+  has_attached_file :image,
+                    url: '/spree/slides/:id/:style/:basename.:extension',
+                    path: ':rails_root/public/spree/slides/:id/:style/:basename.:extension',
+                    convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
   validates_attachment :image, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
   scope :published, -> { where(published: true).order('position ASC') }
 


### PR DESCRIPTION
Should help to avoid server configuration issues. Additionally added the same convert options as in spree/image.rb
Correct the github repository in Readme because this confused me on my first try.