### PR TITLE
Ability to sort Slide object in admin panel

### DIFF
--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -9,11 +9,15 @@ class Spree::Slide < ActiveRecord::Base
                     path: ':rails_root/public/spree/slides/:id/:style/:basename.:extension',
                     convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
   validates_attachment :image, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
+
+  default_scope { order(:position) }
   
-  scope :published, -> { where(published: true).order('position ASC') }
+  scope :published, -> { where(published: true) }
   scope :location, -> (location){ joins(:slide_locations).where('spree_slide_locations.name = ?', location) }
 
   belongs_to :product, touch: true
+
+  acts_as_list
 
   def initialize(attrs = nil)
     attrs ||= {:published => true}

--- a/app/overrides/spree/admin/shared/sub_menu/_configuration/add_slide_locations_to_admin_configurations_sidebar_menu.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration/add_slide_locations_to_admin_configurations_sidebar_menu.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu']" -->
-<%= configurations_sidebar_menu_item t('spree_slider_locations.config_name'), admin_slide_locations_path %>
+<%= configurations_sidebar_menu_item t('spree_slider_location.config_name'), admin_slide_locations_path %>

--- a/app/views/spree/admin/slide_locations/edit.html.erb
+++ b/app/views/spree/admin/slide_locations/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= t('spree_slider_locations.editing_location') %>
+  <%= t('spree_slider_location.editing_location') %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to t('spree_slider_locations.back_to_locations'), spree.admin_slide_locations_path, :icon => 'arrow-left' %>
+  <%= button_link_to t('spree_slider_location.back_to_locations'), spree.admin_slide_locations_path, :icon => 'arrow-left' %>
 <% end %>
 
 <%= render 'spree/shared/error_messages', :target => @slide_location %>

--- a/app/views/spree/admin/slide_locations/index.html.erb
+++ b/app/views/spree/admin/slide_locations/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_actions do %>
-  <%= button_link_to t('spree_slider_locations.new_location'), new_object_url, { :class => 'btn-success', :icon => 'add', :id => 'admin_new_slide_link' } %>
+  <%= button_link_to t('spree_slider_location.new_location'), new_object_url, { :class => 'btn-success', :icon => 'add', :id => 'admin_new_slide_link' } %>
 <% end %>
 
 <% content_for :page_title do %>

--- a/app/views/spree/admin/slides/_edit_slider_locations.html.erb
+++ b/app/views/spree/admin/slides/_edit_slider_locations.html.erb
@@ -1,7 +1,7 @@
 <table class="table">
   <thead>
     <tr data-hook="slider_locations_header">
-      <th><%= t('spree_slider_locations.title') %></th>
+      <th><%= t('spree_slider_location.title') %></th>
     </tr>
   </thead>
   <tbody id='slider_locations'>
@@ -18,7 +18,7 @@
 </table>
 
 <%#= link_to_add_fields t('spree_slider_locations.new_location'), "tbody#slider_locations" %>
-<%= button_link_to t('spree_slider_locations.new_location'), 'javascript:;', {
+<%= button_link_to t('spree_slider_location.new_location'), 'javascript:;', {
       icon: 'add', 
       :'data-target' => 'tbody#slider_locations', 
       class: 'btn-success spree_add_fields' 

--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -1,10 +1,4 @@
 <div class="row">
-  <div class="col-md-2">
-    <%= f.field_container :position do %>
-      <%= f.label :position, t(:position) %>
-      <%= f.number_field :position, :class => 'fullwidth form-control' %>
-    <% end %>
-  </div>
 
   <div class="col-md-10">
     <div class="field checkbox">

--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -1,63 +1,59 @@
 <div class="row">
 
-  <div class="col-md-10">
-    <div class="field checkbox">
-      <label>
-        <%= f.check_box :published, class: "form-control" %>
-        <%= t(:published) %>
-      </label>
+  <div class="col-md-6">
+    <div class="form-group">
+      <%= f.field_container :product_id do %>
+          <%= label_tag :product_id, t(:product) %><br>
+          <%= hidden_field_tag 'slide[product_id]', f.object.product_id.to_s, :class => "product_picker fullwidth" %>
+      <% end %>
     </div>
-  </div>
 
-  <div class="col-md-12">
-    <%= f.field_container :product_id do %>
-      <%= label_tag :product_id, t(:product) %><br>
-      <%= hidden_field_tag 'slide[product_id]', f.object.product_id.to_s, :class => "product_picker fullwidth" %>
-    <% end %>
-  </div>
-
-  <div class="col-md-6">
-    <%= f.field_container :name do %>
+    <div class="form-group">
       <%= f.label :name, t(:name) %><br>
-      <%= f.text_field :name, :class => 'fullwidth', :placeholder => t('spree_slider.placeholder_name'), class: "form-control" %>
-    <% end %>
-  </div>
+      <%= f.text_field :name, :placeholder => t('spree_slider.placeholder_name'), class: "form-control" %>
+    </div>
 
-  <div class="col-md-6">
-    <%= f.field_container :link_url do %>
+    <div class="form-group">
       <%= f.label :link_url, t(:link_url) %><br>
       <%= f.text_field :link_url, :class => 'fullwidth', :placeholder => t('spree_slider.placeholder_link_url'), class: "form-control" %>
-    <% end %>
-  </div>
+    </div>
 
-  <div class="col-md-6">
-    <%= render 'spree/admin/slides/edit_slider_locations', f: f %>
-  </div>
-
-  <div class="col-md-12">
-    <%= f.field_container :body do %>
+    <div class="form-group">
       <%= f.label :body, t(:body) %><br>
-      <%= f.text_area :body, {:cols => 60, :rows => 4, :class => 'fullwidth form-control'} %>
-    <% end %>
-  </div>
+      <%= f.text_area :body, {:rows => 8, :class => 'form-control'} %>
+    </div>
 
-  <div class="col-md-6">
-    <%= f.field_container :image do %>
+    <div class="form-group">
       <%= f.label :image, t(:image) %> <i>(<%= t('spree_slider.image_tip') %>)</i><br>
       <%= f.file_field :image %>
-    <% end %>
-  </div>
+    </div>
 
+  </div>
   <div class="col-md-6">
-    <%= f.field_container :image do %>
-      <% if f.object.image? %>
-        <p>
-          <%= label_tag t(:preview) %>
-          <br>
-          <%= image_tag f.object.image, class: 'img-responsive' %>
-        </p>
+    <div class="form-group">
+      <div class="field checkbox">
+        <label>
+          <%= f.check_box :published, class: "form-control" %>
+          <%= t(:published) %>
+        </label>
+      </div>
+    </div>
+
+    <div class="form-group" style="margin-top: 50px">
+      <%= render 'spree/admin/slides/edit_slider_locations', f: f %>
+    </div>
+
+    <div class="form-group">
+      <%= f.field_container :image do %>
+        <% if f.object.image? %>
+          <p>
+            <%= label_tag t(:preview) %>
+            <br>
+            <%= image_tag f.object.image, class: 'img-responsive' %>
+          </p>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   </div>
 
 </div>

--- a/app/views/spree/admin/slides/index.html.erb
+++ b/app/views/spree/admin/slides/index.html.erb
@@ -6,33 +6,40 @@
   <%= t('spree_slider.title') %>
 <% end %>
 
-<table class="table sortable" id="listing_slides" data-hook data-sortable-link="<%= update_positions_admin_slides_url %>" >
-  <thead>
-  <tr data-hook="admin_slides_index_headers">
-    <th colspan="2"><%= Spree.t(:image) %></th>
-    <th><%= Spree.t(:name) %></th>
-    <th><%= Spree.t(:product) %></th>
-    <th><%= Spree.t(:published) %></th>
-    <th data-hook="admin_slides_index_header_actions" class="actions"></th>
-  </tr>
-  </thead>
-  <tbody>
-  <% @slides.each do |slide|%>
-    <tr id="<%= spree_dom_id slide %>" data-hook="admin_slides_index_rows">
-      <td class="no-border">
-        <span class="handle"></span>
-      </td>
-      <td class="align-center"><%= image_tag slide.slide_image, style: 'width: 120px; height: auto;' %></td>
-      <td class="align-center"><%= link_to slide.name, object_url(slide) %></td>
-      <td class="align-center"><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
-      <td class="align-center"><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
-      <td data-hook="admin_slides_index_row_actions" class="actions">
-        <%= link_to_edit slide, :no_text => true, :class => 'edit' %>
-        &nbsp;
-        <%= link_to_delete slide, :no_text => true %>
-      </td>
+<% if @slides.any? %>
+  <table class="table sortable" id="listing_slides" data-hook="slides_table" data-sortable-link="<%= update_positions_admin_slides_url %>" >
+    <thead>
+    <tr data-hook="admin_slides_index_headers">
+      <th class="no-border"></th>
+      <th><%= Spree.t(:image) %></th>
+      <th><%= Spree.t(:name) %></th>
+      <th><%= Spree.t(:product) %></th>
+      <th><%= Spree.t(:published) %></th>
+      <th data-hook="admin_slides_index_header_actions" class="actions"></th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
-
+    </thead>
+    <tbody>
+    <% @slides.each do |slide|%>
+      <tr id="<%= spree_dom_id slide %>" data-hook="admin_slides_index_rows">
+        <td class="move-handle text-center">
+          <span class="icon icon-move handle"></span>
+        </td>
+        <td class="align-center"><%= image_tag slide.slide_image, style: 'width: 120px; height: auto;' %></td>
+        <td class="align-center"><%= link_to slide.name, object_url(slide) %></td>
+        <td class="align-center"><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
+        <td class="align-center"><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+        <td data-hook="admin_slides_index_row_actions" class="actions">
+          <%= link_to_edit slide, :no_text => true, :class => 'edit' %>
+          &nbsp;
+          <%= link_to_delete slide, :no_text => true %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alert alert-warning no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: Spree::Slide.model_name.human) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_slide_path %>!
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
     placeholder_link_url: "Leave blank to use product url"
     image_tip: "Default first product image"
 
-  spree_slider_locations:
+  spree_slider_location:
     config_name: "Spree Slider Locations"
     config_description: "Manage Spree Slider Locations"
     title: "Slider Locations"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -27,7 +27,7 @@ pt-BR:
     placeholder_link_url: "Deixe em branco para usar a url do produto"
     image_tip: "Padrão é a primeira imagem do produto"
 
-  spree_slider_locations:
+  spree_slider_location:
     config_name: "Locais do Spree Slider"
     config_description: "Configurações de Locais do Spree Slider"
     title: "Locais do Slider"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,16 +1,18 @@
 ru:
-  next: "Следующий"
-  previous: "Предыдущий"
-  name: "Название"
   body: "Содержимое"
-  link_url: "URL для ссылки"
   image: "Изображение"
   image_file_name: "Имя файла изображения"
-  published: "Опубликован"
-  position: "Позиция"
-  y: "Да"
+  link_url: "URL для ссылки"
   n: "Нет"
-  
+  name: "Название"
+  next: "Следующий"
+  position: "Позиция"
+  preview: 'Предпоказ'
+  previous: "Предыдущий"
+  product: "Продукт"
+  published: "Опубликован"
+  y: "Да"
+
   activerecord:
     models:
       spree/slide: "Слайд"
@@ -25,3 +27,11 @@ ru:
     placeholder_name: "Оставьте пустым, чтобы использовать название выбранного продукта"
     placeholder_link_url: "Оставьте пустым, чтобы использовать url продукта"
     image_tip: "Изображение продукта"  
+
+  spree_slider_location:
+    back_to_locations: "Назад к расположениям"
+    config_description: "Работа с расположением слайдов"
+    config_name: "Расположение слайдов"
+    editing_location: "Редактирование расположения"
+    new_location: "Новое расположение"
+    title: "Расположение слайдов"


### PR DESCRIPTION
Slides not acted as list, so there is no need to manually set `position` value. Sorting is not made by drag-and-drop as it is made with  for example `Spree::OptionType` and `Spree::Taxonomy`.
Reconstructed `_form.html.erb` for `Spree::Slide` for better view.
Improved some locale files.
