### PR TITLE
fix indicator target

### DIFF
--- a/app/views/spree/shared/_slider.html.erb
+++ b/app/views/spree/shared/_slider.html.erb
@@ -7,7 +7,7 @@
     <%# Indicators %>
     <ol class="carousel-indicators">
       <% slider.each_with_index do |slide, index| %>
-        <li data-target="#carousel-prod-<%= cid %>" data-slide-to="<%= index %>" class="<%= index == 0 ? 'active' : '' %>"></li>
+        <li data-target="#carousel-slider-<%= cid %>" data-slide-to="<%= index %>" class="<%= index == 0 ? 'active' : '' %>"></li>
       <% end %>
     </ol>
 


### PR DESCRIPTION
The data-target attribute of the indicator was wrong so the slider didn't slide to the slide when the indicator was clicked.