### PR TITLE
Set spree dependencies to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_slider.gemspec
+++ b/spree_slider.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '>= 3.2.0.alpha'
-  s.add_dependency 'spree_backend', '>= 3.2.0.alpha'
+  s.add_dependency 'spree_core', '>= 3.1.0', '< 4.0'
+  s.add_dependency 'spree_backend', '>= 3.1.0', '< 4.0'
 end


### PR DESCRIPTION
This PR changes the version of spree dependencies in gemspec to point at `>= 3.1.0` and `< 4.0`.