### PR TITLE
Fix Rails > 5.1 migration error

### DIFF
--- a/db/migrate/20120222184238_create_slides.rb
+++ b/db/migrate/20120222184238_create_slides.rb
@@ -1,4 +1,4 @@
-class CreateSlides < ActiveRecord::Migration
+class CreateSlides < SpreeExtension::Migration[5.0]
   def change
     create_table :spree_slides do |t|
       t.string :name

--- a/db/migrate/20120816192758_add_position_to_slides.rb
+++ b/db/migrate/20120816192758_add_position_to_slides.rb
@@ -1,4 +1,4 @@
-class AddPositionToSlides < ActiveRecord::Migration
+class AddPositionToSlides < SpreeExtension::Migration[5.0]
   def change
     add_column :spree_slides, :position, :integer, :null => false, :default => 0
   end

--- a/db/migrate/20121219124126_add_product_id_to_slides.rb
+++ b/db/migrate/20121219124126_add_product_id_to_slides.rb
@@ -1,4 +1,4 @@
-class AddProductIdToSlides < ActiveRecord::Migration
+class AddProductIdToSlides < SpreeExtension::Migration[5.0]
   def change
     add_column :spree_slides, :product_id, :integer
   end

--- a/db/migrate/20150611113500_create_slider_location.rb
+++ b/db/migrate/20150611113500_create_slider_location.rb
@@ -1,5 +1,4 @@
-class CreateSliderLocation < ActiveRecord::Migration
-
+class CreateSliderLocation < SpreeExtension::Migration[5.0]
   def change
     create_table :spree_slide_locations do |t|
       t.string :name


### PR DESCRIPTION
**Resolves issue #36**
Inheriting from SpreeExtension::Migration[5.0] will resolve problem with failed migrations in different framework versions.