### PR TITLE
Fix image_tag

### DIFF
--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -29,6 +29,20 @@ class Spree::Slide < ActiveRecord::Base
   end
 
   def slide_image
-    !image.file? && product.present? && product.images.any? ? product.images.first.attachment : image
+    if !has_image? && has_product_image?
+      product.images.first.attachment
+    else
+      image
+    end
+  end
+
+  private
+
+  def has_image?
+    image.file?
+  end
+
+  def has_product_image?
+    product&.images&.any? && product.images.first.attachment.file?
   end
 end

--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -60,10 +60,9 @@
         <p>
           <%= label_tag t(:preview) %>
           <br>
-          <%= image_tag f.object.image, class: 'img-responsive' %>
+          <%= image_tag f.object.image.url, class: 'img-responsive' %>
         </p>
       <% end %>
     <% end %>
   </div>
-
 </div>

--- a/app/views/spree/admin/slides/index.html.erb
+++ b/app/views/spree/admin/slides/index.html.erb
@@ -22,7 +22,7 @@
       <td class="no-border">
         <span class="handle"></span>
       </td>
-      <td class="align-center"><%= image_tag slide.slide_image, style: 'width: 120px; height: auto;' %></td>
+      <td class="align-center"><%= image_tag slide.slide_image.url, style: 'width: 120px; height: auto;' %></td>
       <td class="align-center"><%= link_to slide.name, object_url(slide) %></td>
       <td class="align-center"><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
       <td class="align-center"><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
@@ -35,4 +35,3 @@
   <% end %>
   </tbody>
 </table>
-

--- a/app/views/spree/admin/slides/index.html.erb
+++ b/app/views/spree/admin/slides/index.html.erb
@@ -8,30 +8,30 @@
 
 <table class="table sortable" id="listing_slides" data-hook data-sortable-link="<%= update_positions_admin_slides_url %>" >
   <thead>
-  <tr data-hook="admin_slides_index_headers">
-    <th colspan="2"><%= Spree.t(:image) %></th>
-    <th><%= Spree.t(:name) %></th>
-    <th><%= Spree.t(:product) %></th>
-    <th><%= Spree.t(:published) %></th>
-    <th data-hook="admin_slides_index_header_actions" class="actions"></th>
-  </tr>
+    <tr data-hook="admin_slides_index_headers">
+      <th colspan="2"><%= Spree.t(:image) %></th>
+      <th><%= Spree.t(:name) %></th>
+      <th><%= Spree.t(:product) %></th>
+      <th><%= Spree.t(:published) %></th>
+      <th data-hook="admin_slides_index_header_actions" class="actions"></th>
+    </tr>
   </thead>
   <tbody>
-  <% @slides.each do |slide|%>
-    <tr id="<%= spree_dom_id slide %>" data-hook="admin_slides_index_rows">
-      <td class="no-border">
-        <span class="handle"></span>
-      </td>
-      <td class="align-center"><%= image_tag slide.slide_image.url, style: 'width: 120px; height: auto;' %></td>
-      <td class="align-center"><%= link_to slide.name, object_url(slide) %></td>
-      <td class="align-center"><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
-      <td class="align-center"><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
-      <td data-hook="admin_slides_index_row_actions" class="actions">
-        <%= link_to_edit slide, no_text: true, class: 'edit' %>
-        &nbsp;
-        <%= link_to_delete slide, no_text: true %>
-      </td>
-    </tr>
-  <% end %>
+    <% @slides.each do |slide|%>
+      <tr id="<%= spree_dom_id slide %>" data-hook="admin_slides_index_rows">
+        <td class="no-border">
+          <span class="handle"></span>
+        </td>
+        <td class="align-center"><%= image_tag slide.slide_image.url, style: 'width: 120px; height: auto;' %></td>
+        <td class="align-center"><%= link_to slide.name, object_url(slide) %></td>
+        <td class="align-center"><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
+        <td class="align-center"><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+        <td data-hook="admin_slides_index_row_actions" class="actions">
+          <%= link_to_edit slide, no_text: true, class: 'edit' %>
+          &nbsp;
+          <%= link_to_delete slide, no_text: true %>
+        </td>
+      </tr>
+    <% end %>
   </tbody>
 </table>


### PR DESCRIPTION
Rails 5.2 changed behavior for ```image_tag```, now it accepts only image URL. In Rails 5.1 it was possible to pass just uploader object. So in Rails 5.2 it will fall with ```NoMethodError``` when rendering index or _form views. Here I add url method call to solve this problem, also fix incorrect indentation in this files.