### PR TITLE
Add `optional: true` to `belongs_to` to retain the rails<5 behaviour.

### DIFF
--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -13,7 +13,7 @@ class Spree::Slide < ActiveRecord::Base
   scope :published, -> { where(published: true).order('position ASC') }
   scope :location, -> (location) { joins(:slide_locations).where('spree_slide_locations.name = ?', location) }
 
-  belongs_to :product, touch: true
+  belongs_to :product, touch: true, optional: true
 
   def initialize(attrs = nil)
     attrs ||= { published: true }


### PR DESCRIPTION
Rails 5 makes belongs_to relations required by default.[1]

This patch ensures the behaviour to provide a product *or* an URL remains the same between Rails 4.x and 5.

--
[1] https://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html